### PR TITLE
Fix undefined movies tv refresh (#241)

### DIFF
--- a/app/components/ContentPoster.tsx
+++ b/app/components/ContentPoster.tsx
@@ -1,0 +1,223 @@
+import { Box, Typography, Stack, useTheme } from "@mui/material";
+import MovieIcon from "@mui/icons-material/Movie";
+import TvIcon from "@mui/icons-material/Tv";
+import { motion } from "framer-motion";
+
+interface ContentPosterProps {
+  posterPath: string | null | undefined;
+  title: string;
+  mediaType?: "tv" | "movie";
+  height?: number | string;
+  width?: number | string;
+  sx?: any;
+}
+
+export default function ContentPoster({
+  posterPath,
+  title,
+  mediaType,
+  height = 300,
+  width = "100%",
+  sx,
+}: ContentPosterProps) {
+  const theme = useTheme();
+
+  if (posterPath) {
+    return (
+      <Box
+        component={motion.img}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5 }}
+        src={`https://image.tmdb.org/t/p/w500${posterPath}`}
+        alt={title}
+        sx={{
+          width: width,
+          height: height,
+          objectFit: "cover",
+          display: "block",
+          ...sx,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box
+      component={motion.div}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.4 }}
+      sx={{
+        width: width,
+        height: height,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.secondary.main} 100%)`,
+        color: "white",
+        p: 3,
+        textAlign: "center",
+        position: "relative",
+        overflow: "hidden",
+        ...sx,
+      }}
+    >
+      {/* Dynamic particles or subtle circles in background */}
+      <Box
+        component={motion.div}
+        animate={{
+          scale: [1, 1.2, 1],
+          rotate: [0, 90, 0],
+        }}
+        transition={{
+          duration: 20,
+          repeat: Infinity,
+          ease: "linear"
+        }}
+        sx={{
+          position: "absolute",
+          top: -100,
+          left: -100,
+          width: 300,
+          height: 300,
+          borderRadius: "50%",
+          background: "rgba(255, 255, 255, 0.05)",
+          zIndex: 0,
+        }}
+      />
+
+      <Stack
+        spacing={height && !isNaN(Number(height)) && Number(height) < 200 ? 1 : 2}
+        alignItems="center"
+        sx={{ zIndex: 1, width: "100%" }}
+      >
+        <motion.div
+          animate={{
+            y: [0, -5, 0],
+          }}
+          transition={{
+            duration: 3,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+        >
+          {mediaType === "tv" ? (
+            <TvIcon
+              sx={{
+                fontSize:
+                  height && !isNaN(Number(height)) && Number(height) < 200
+                    ? 32
+                    : 48,
+                opacity: 0.9,
+                filter: "drop-shadow(0 4px 8px rgba(0,0,0,0.3))",
+              }}
+            />
+          ) : (
+            <MovieIcon
+              sx={{
+                fontSize:
+                  height && !isNaN(Number(height)) && Number(height) < 200
+                    ? 32
+                    : 48,
+                opacity: 0.9,
+                filter: "drop-shadow(0 4px 8px rgba(0,0,0,0.3))",
+              }}
+            />
+          )}
+        </motion.div>
+
+        <Typography
+          variant="h6"
+          fontWeight="bold"
+          sx={{
+            lineHeight: 1.1,
+            textShadow: "0 2px 8px rgba(0,0,0,0.4)",
+            wordBreak: "break-word",
+            px: 1,
+            // Dynamic font size and clamping based on height
+            fontSize:
+              height && !isNaN(Number(height)) && Number(height) < 200
+                ? "0.85rem"
+                : "1.25rem",
+            display: "-webkit-box",
+            WebkitLineClamp:
+              height && !isNaN(Number(height)) && Number(height) < 200 ? 3 : 6,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {title}
+        </Typography>
+
+        <Box
+          sx={{
+            py: 0.25,
+            px: 1.25,
+            borderRadius: 5,
+            bgcolor: "rgba(255,255,255,0.2)",
+            backdropFilter: "blur(4px)",
+          }}
+        >
+          <Typography
+            variant="caption"
+            sx={{
+              opacity: 1,
+              textTransform: "uppercase",
+              letterSpacing: 1.2,
+              fontWeight: 700,
+              fontSize:
+                height && !isNaN(Number(height)) && Number(height) < 200
+                  ? "0.55rem"
+                  : "0.65rem",
+            }}
+          >
+            {mediaType === "tv" ? "TV Series" : "Movie"}
+          </Typography>
+        </Box>
+      </Stack>
+
+      {/* Decorative background element with motion */}
+      <Box
+        component={motion.div}
+        animate={{
+          rotate: [-15, -10, -15],
+          scale: [1, 1.05, 1],
+        }}
+        transition={{
+          duration: 10,
+          repeat: Infinity,
+          ease: "easeInOut"
+        }}
+        sx={{
+          position: "absolute",
+          bottom: -20,
+          right: -20,
+          opacity: 0.15,
+          zIndex: 0,
+        }}
+      >
+        {mediaType === "tv" ? (
+          <TvIcon sx={{ fontSize: 180 }} />
+        ) : (
+          <MovieIcon sx={{ fontSize: 180 }} />
+        )}
+      </Box>
+
+      {/* Subtle overlay for depth */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: "radial-gradient(circle at center, transparent 0%, rgba(0,0,0,0.2) 100%)",
+          zIndex: 0,
+        }}
+      />
+    </Box>
+  );
+}

--- a/app/tv/ContentSearchBar.tsx
+++ b/app/tv/ContentSearchBar.tsx
@@ -14,17 +14,16 @@ import {
 import { debounce } from "lodash";
 import { useMemo, useState } from "react";
 
+import ContentPoster from "@/components/ContentPoster";
 import { addContentToFirebase } from "./firebaseUtils";
 import {
-  Content,
   EmZContent,
   fetchDataFromTMDB,
-  Movie,
   TMDBSearchMultiResponse,
-  TVShow,
   whoOptions,
   WhoSelection,
 } from "./utils";
+import { TMDBSearchItem } from "@shared/tv/types";
 
 import {
   mapTvData,
@@ -45,10 +44,12 @@ export default function ContentSearchBar({
   fetchSearchResults,
 }: SearchBarProps<TMDBSearchMultiResponse>) {
   const [inputValue, setInputValue] = useState("");
-  const [options, setOptions] = useState<Content[]>([]);
+  const [options, setOptions] = useState<TMDBSearchItem[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [who, setWho] = useState<WhoSelection>("Both");
-  const [selectedContent, setSelectedContent] = useState<Content | null>(null);
+  const [selectedContent, setSelectedContent] = useState<TMDBSearchItem | null>(
+    null,
+  );
 
   const debouncedFetch = useMemo(() => {
     const fetchResults = async (query) => {
@@ -76,7 +77,7 @@ export default function ContentSearchBar({
     debouncedFetch(value);
   };
 
-  const addContent = async (value: Content, who: WhoSelection) => {
+  const addContent = async (value: TMDBSearchItem, who: WhoSelection) => {
     const isTv = value.media_type === "tv";
     const id = value.id;
     const url = isTv
@@ -120,7 +121,12 @@ export default function ContentSearchBar({
             );
             if (!movieData) continue;
 
-            const partBase = { id: movieId, who, watched: 0, media_type: "movie" };
+            const partBase = {
+              id: movieId,
+              who,
+              watched: 0,
+              media_type: "movie",
+            };
             const { data: partData } = mapMovieData(partBase as any, movieData);
             const partDoc = partData as unknown as EmZContent;
 
@@ -153,13 +159,11 @@ export default function ContentSearchBar({
         getOptionLabel={(option) => {
           return typeof option === "string"
             ? option
-            : option.media_type === "tv"
-              ? (option as TVShow).name
-              : (option as Movie).title;
+            : option.name || option.title || "";
         }}
         onInputChange={handleInputChange}
         onChange={(event, value) => {
-          setSelectedContent(value as Content | null);
+          setSelectedContent(value as TMDBSearchItem | null);
         }}
         loading={loading}
         sx={{ flex: 1 }}
@@ -205,22 +209,19 @@ export default function ContentSearchBar({
                 p: "8px !important",
               }}
             >
-              <Avatar
-                key={`${mediaKey}-avatar`}
-                alt={
-                  option.media_type === "tv"
-                    ? (option as TVShow).name
-                    : (option as Movie).title
+              <ContentPoster
+                posterPath={option.poster_path}
+                title={
+                  option.media_type === "tv" ? option.name! : option.title!
                 }
-                src={`https://image.tmdb.org/t/p/w154/${option.poster_path}`}
-                variant="rounded"
-                sx={{ height: 120, width: 80 }}
+                mediaType={option.media_type}
+                height={120}
+                width={80}
+                sx={{ borderRadius: 2 }}
               />
               <Box key={`${mediaKey}-info`}>
                 <Typography variant="body1" fontWeight="medium">
-                  {option.media_type === "tv"
-                    ? (option as TVShow).name
-                    : (option as Movie).title}
+                  {option.media_type === "tv" ? option.name : option.title}
                 </Typography>
                 <Typography
                   variant="caption"

--- a/app/tv/NextShow.tsx
+++ b/app/tv/NextShow.tsx
@@ -4,22 +4,21 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
-  Avatar,
   Typography,
   Stack,
 } from "@mui/material";
 import { GridRowsProp } from "@mui/x-data-grid";
 import { useState } from "react";
 
-import { EmZContent, EmZGenre } from "./utils";
+import ContentPoster from "@/components/ContentPoster";
+import { EmZContent } from "./utils";
 import { applyFilters } from "./utils";
 type NextShowProps = {
   rows: GridRowsProp;
-  genres: Record<number, EmZGenre> | null;
 };
-export default function NextShow({ rows, genres }: NextShowProps) {
+export default function NextShow({ rows }: NextShowProps) {
   const [selectedContent, setSelectedContent] = useState<EmZContent | null>(
-    null
+    null,
   );
   const [open, setOpen] = useState(false);
   return (
@@ -35,22 +34,20 @@ export default function NextShow({ rows, genres }: NextShowProps) {
         {selectedContent && (
           <DialogContent>
             <Stack direction={"row"} spacing={2} alignItems={"center"}>
-              <Avatar
-                src={`https://image.tmdb.org/t/p/w500${selectedContent.poster_path}`}
-                variant="square"
-                sx={{ width: 100, height: "100%" }}
+              <ContentPoster
+                posterPath={selectedContent.poster_path}
+                title={selectedContent.name || selectedContent.title || ""}
+                mediaType={selectedContent.media_type}
+                height={150}
+                width={100}
+                sx={{ borderRadius: 1 }}
               />
               <Stack>
                 <Typography variant="h4">{selectedContent.name}</Typography>
                 <Typography>Selected By: {selectedContent.who}</Typography>
                 <Typography>Overview: {selectedContent.overview}</Typography>
                 <Typography>
-                  Genres:{" "}
-                  {selectedContent.genre_ids
-                    .map((id) => {
-                      if (genres) return genres[id].name;
-                    })
-                    .join(", ")}
+                  {`Genres: ${selectedContent.genres?.map((g) => g.name).join(", ")}`}
                 </Typography>
                 <Typography>Episodes: {selectedContent.episodes}</Typography>
               </Stack>

--- a/app/tv/TVCard.tsx
+++ b/app/tv/TVCard.tsx
@@ -5,14 +5,12 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import RemoveIcon from "@mui/icons-material/Remove";
 import {
   Card,
-  CardMedia,
   CardContent,
   Typography,
   Box,
   LinearProgress,
   IconButton,
   Chip,
-  Stack,
   Menu,
   MenuItem,
   Avatar,
@@ -24,22 +22,22 @@ import {
 } from "@mui/material";
 import { useState, useEffect } from "react";
 
+import ContentPoster from "@/components/ContentPoster";
 import CircularProgressWithLabel from "@/components/CircularProgressWithLabel";
 
 import {
   EmZContent,
-  EmZGenre,
   whoOptions,
   NextEpisodeToAir,
   Provider,
   ContentStatus,
   fetchDataFromTMDB,
   Season,
+  getGenreColor,
 } from "./utils";
 
 interface TVCardProps {
   item: EmZContent;
-  genres: Record<number, EmZGenre> | null;
   providers: Provider[];
   onUpdate: (updatedItem: EmZContent) => Promise<void>;
   onDelete: (id: number) => void;
@@ -47,7 +45,6 @@ interface TVCardProps {
 
 export default function TVCard({
   item,
-  genres,
   providers,
   onUpdate,
   onDelete,
@@ -186,16 +183,11 @@ export default function TVCard({
       }}
     >
       <Box sx={{ position: "relative" }}>
-        <CardMedia
-          component="img"
-          height="300"
-          image={
-            item.poster_path
-              ? `https://image.tmdb.org/t/p/w500${item.poster_path}`
-              : "/favicon.png"
-          }
-          alt={title}
-          sx={{ objectFit: "cover" }}
+        <ContentPoster
+          posterPath={item.poster_path}
+          title={title}
+          mediaType={item.media_type}
+          height={300}
         />
 
         {/* Status Chip */}
@@ -313,16 +305,16 @@ export default function TVCard({
 
         {/* Genres */}
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-          {item.genre_ids?.map((id) => {
-            const genre = genres?.[id];
-            return genre ? (
+          {item.genres?.map((g) => {
+            const color = getGenreColor(g.id);
+            return (
               <Chip
-                key={id}
-                label={genre.name}
+                key={g.id}
+                label={g.name}
                 size="small"
-                sx={{ bgcolor: genre.color, fontSize: "0.7rem", height: 20 }}
+                sx={{ bgcolor: color, fontSize: "0.7rem", height: 20 }}
               />
-            ) : null;
+            );
           })}
         </Box>
 

--- a/app/tv/TVPage.tsx
+++ b/app/tv/TVPage.tsx
@@ -10,16 +10,8 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  Chip,
-  TextField,
-  Avatar,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
 } from "@mui/material";
 import { useState, useEffect, useCallback } from "react";
-import ArrowDropDown from "@mui/icons-material/ArrowDropDown";
-
 import ContentSearchBar from "./ContentSearchBar";
 import {
   addContentToFirebase,
@@ -28,22 +20,18 @@ import {
   subscribeToAllProvidersFromFirebase,
 } from "./firebaseUtils";
 import NetworkPage from "./NetworkPage";
-import TableToolbar, { CustomToolbarProps } from "./TableToolbar";
+import TableToolbar from "./TableToolbar";
 import TVCard from "./TVCard";
 import {
   EmZContent,
-  fetchGenres,
-  EmZGenre,
   Filter,
   Provider,
   applyFiltersAndSorts,
-  fetchDataFromTMDB,
   fetchContentSearchResults,
 } from "./utils";
 
 export default function TVPage() {
   const [rows, setRows] = useState<EmZContent[]>([]);
-  const [genres, setGenres] = useState<Record<number, EmZGenre> | null>(null);
   const [filters, setFilters] = useState<Record<string, Filter<EmZContent>>>(
     {},
   );
@@ -64,15 +52,6 @@ export default function TVPage() {
     }
   };
 
-
-  useEffect(() => {
-    if (!genres) {
-      fetchGenres().then((genreData) => {
-        setGenres(genreData as Record<number, EmZGenre>);
-      });
-    }
-  }, [genres]);
-
   useEffect(() => {
     setRowsLoading(true);
 
@@ -88,10 +67,14 @@ export default function TVPage() {
       setRowsLoading(false);
     });
 
-    const unsubscribeProviders = subscribeToAllProvidersFromFirebase((snapshot) => {
-      const providersData = snapshot.docs.map((doc) => doc.data() as Provider);
-      setProviders(providersData);
-    });
+    const unsubscribeProviders = subscribeToAllProvidersFromFirebase(
+      (snapshot) => {
+        const providersData = snapshot.docs.map(
+          (doc) => doc.data() as Provider,
+        );
+        setProviders(providersData);
+      },
+    );
 
     return () => {
       unsubscribeContent();
@@ -100,10 +83,9 @@ export default function TVPage() {
   }, []);
 
   const handleDelete = (id: number) => {
-    deleteContentFromFirebase(id)
-      .catch((error) => {
-        console.error("Error deleting content:", error);
-      });
+    deleteContentFromFirebase(id).catch((error) => {
+      console.error("Error deleting content:", error);
+    });
   };
 
   return (
@@ -120,7 +102,6 @@ export default function TVPage() {
         <Box sx={{ width: "100%" }}>
           <TableToolbar
             rows={rows}
-            genres={genres}
             filters={filters}
             setFilters={setFilters}
             setRows={setRows}
@@ -139,7 +120,6 @@ export default function TVPage() {
               <Grid key={item.id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
                 <TVCard
                   item={item}
-                  genres={genres}
                   providers={providers}
                   onUpdate={handleUpdateInfo}
                   onDelete={handleDelete}

--- a/app/tv/TableToolbar.tsx
+++ b/app/tv/TableToolbar.tsx
@@ -9,23 +9,9 @@ import {
   fetchAllContentFromFirebase,
 } from "./firebaseUtils";
 import NextShow from "./NextShow";
-import {
-  EmZContent,
-  fetchDataFromTMDB,
-  Filter,
-  TMDBError,
-  WhoSelection,
-  EmZGenre,
-} from "./utils";
+import { EmZContent, Filter } from "./utils";
 
-import {
-  mapTvData,
-  mapMovieData,
-  findNewCollectionMovies,
-  fetchContentUpdatesFromTMDB as sharedFetchContentUpdates,
-  CollectionRef,
-  delay,
-} from "@shared/tv/functions";
+import { fetchContentUpdatesFromTMDB as sharedFetchContentUpdates } from "@shared/tv/functions";
 export type TableToolbarProps = {
   filters: Record<string, Filter<EmZContent>>;
   setFilters: Dispatch<
@@ -35,7 +21,6 @@ export type TableToolbarProps = {
 
 export type CustomToolbarProps = {
   rows: EmZContent[];
-  genres: Record<number, EmZGenre> | null;
   filters: Record<string, Filter<EmZContent>>;
   setFilters: Dispatch<
     React.SetStateAction<Record<string, Filter<EmZContent>>>
@@ -46,7 +31,6 @@ export type CustomToolbarProps = {
 };
 export default function TableToolbar({
   rows,
-  genres,
   filters,
   setFilters,
   setRows,
@@ -59,7 +43,7 @@ export default function TableToolbar({
       spacing={2}
       sx={{ mb: 2, alignItems: "center", flexWrap: "wrap" }}
     >
-      <NextShow rows={rows} genres={genres} />
+      <NextShow rows={rows} />
 
       <FilterButton
         filters={filters}
@@ -107,8 +91,8 @@ export default function TableToolbar({
                     const nameMatch =
                       item.name?.toLowerCase().includes(val) ||
                       item.title?.toLowerCase().includes(val);
-                    const genreMatch = item.genre_ids?.some((id) =>
-                      genres?.[id]?.name.toLowerCase().includes(val),
+                    const genreMatch = item.genres?.some((g) =>
+                      g.name.toLowerCase().includes(val),
                     );
                     const whoMatch = item.who?.toLowerCase().includes(val);
                     return nameMatch || genreMatch || whoMatch;

--- a/app/tv/utils.tsx
+++ b/app/tv/utils.tsx
@@ -8,7 +8,6 @@ import {
   Provider,
   TMDBSearchMultiResponse,
   TMDBGenre,
-  EmZGenre,
   WhoSelection,
   TMDBError,
   ContentStatus,
@@ -23,7 +22,6 @@ export type {
   Provider,
   TMDBSearchMultiResponse,
   TMDBGenre,
-  EmZGenre,
   WhoSelection,
   TMDBError,
 };
@@ -53,25 +51,8 @@ export const fetchWatchProvidersSearchResults = async (query: string) => {
   return filteredData;
 };
 
-export const fetchGenres = async () => {
-  const movieUrl = "https://api.themoviedb.org/3/genre/movie/list";
-  const movieData = await fetchDataFromTMDB(movieUrl);
-  const movieGenres: TMDBGenre[] = movieData?.genres || [];
-
-  const tvUrl = "https://api.themoviedb.org/3/genre/tv/list";
-  const tvData = await fetchDataFromTMDB(tvUrl);
-  const tvGenres: TMDBGenre[] = tvData?.genres || [];
-
-  return [...movieGenres, ...tvGenres].reduce(
-    (prev: Record<number, EmZGenre>, curr) => {
-      prev[curr.id] = {
-        name: curr.name,
-        color: `hsl(${(curr.id * 50) % 360}, 70%, 80%)`,
-      };
-      return prev;
-    },
-    {},
-  );
+export const getGenreColor = (id: number) => {
+  return `hsl(${(id * 50) % 360}, 70%, 80%)`;
 };
 
 export const fetchDataFromTMDB = async (url: string) => {

--- a/shared/tv/functions.ts
+++ b/shared/tv/functions.ts
@@ -34,8 +34,11 @@ export const mapTvData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tmdbData: any
 ): Record<string, unknown> => {
+  // todo(emily): remove after backfill
+  const { genre_ids, ...rest } = docData;
   return {
-    ...docData,
+    ...rest,
+    id: tmdbData.id,
     original_name: tmdbData.original_name,
     name: tmdbData.name,
     next_episode_to_air: tmdbData.next_episode_to_air ?? null,
@@ -47,7 +50,7 @@ export const mapTvData = (
     ongoing: tmdbData.in_production,
     adult: tmdbData.adult,
     backdrop_path: tmdbData.backdrop_path,
-    genre_ids: (tmdbData.genres as TMDBGenre[]).map((g) => g.id),
+    genres: tmdbData.genres as TMDBGenre[],
     original_language: tmdbData.original_language,
     overview: tmdbData.overview,
     popularity: tmdbData.popularity,
@@ -72,13 +75,16 @@ export const mapMovieData = (
         who: (docData.who as WhoSelection) ?? "Both",
       }
     : null;
+    
+  const { genre_ids, ...rest } = docData;
 
   return {
     data: {
-      ...docData,
+      ...rest,
+      id: tmdbData.id,
       adult: tmdbData.adult,
       backdrop_path: tmdbData.backdrop_path,
-      genre_ids: (tmdbData.genres as TMDBGenre[]).map((g) => g.id),
+      genres: tmdbData.genres as TMDBGenre[],
       overview: tmdbData.overview,
       popularity: tmdbData.popularity,
       poster_path: tmdbData.poster_path,

--- a/shared/tv/types.ts
+++ b/shared/tv/types.ts
@@ -56,7 +56,7 @@ export type WhoSelection = "Emily" | "Brian" | "Both";
 export interface Content {
   adult: boolean;
   backdrop_path: string;
-  genre_ids: number[];
+  genres: TMDBGenre[];
   id: number;
   original_language: string;
   overview: string;
@@ -64,7 +64,7 @@ export interface Content {
   poster_path: string;
   vote_average: number;
   vote_count: number;
-  media_type?: string;
+  media_type?: "tv" | "movie";
 }
 
 export interface NextEpisodeToAir {
@@ -142,14 +142,27 @@ export interface TMDBGenre {
   name: string;
 }
 
-export interface EmZGenre {
-  name: string;
-  color: string;
+
+
+export interface TMDBSearchItem {
+  id: number;
+  media_type: "tv" | "movie";
+  poster_path: string;
+  genre_ids: number[];
+  adult: boolean;
+  backdrop_path: string;
+  original_language: string;
+  overview: string;
+  popularity: number;
+  vote_average: number;
+  vote_count: number;
+  name?: string;
+  title?: string;
 }
 
 export interface TMDBSearchMultiResponse {
   page: number;
-  results: Content[];
+  results: TMDBSearchItem[];
   total_pages: number;
   total_results: number;
 }

--- a/test/tv/fetchContentUpdatesFromTMDB.test.ts
+++ b/test/tv/fetchContentUpdatesFromTMDB.test.ts
@@ -48,7 +48,7 @@ describe("mapTvData", () => {
     expect(result.episodes).toBe(73);
     expect(result.ongoing).toBe(false);
     expect(result.adult).toBe(false);
-    expect(result.genre_ids).toEqual([18, 10765]);
+    expect(result.genres).toEqual(tmdbTvResponse.genres);
     expect(result.original_language).toBe("en");
     expect(result.popularity).toBe(369.594);
     expect(result.vote_average).toBe(8.4);
@@ -116,7 +116,7 @@ describe("mapMovieData", () => {
     expect(data.title).toBe("The Matrix");
     expect(data.original_title).toBe("The Matrix");
     expect(data.release_date).toBe("1999-03-31");
-    expect(data.genre_ids).toEqual([28]);
+    expect(data.genres).toEqual(tmdbMovieResponse.genres);
     expect(data.episodes).toBe(1);
     expect(data.ongoing).toBe(false);
     expect(data.vote_average).toBe(8.7);


### PR DESCRIPTION
* feat: update TVCard to support episode-level tracking with lazy-loaded metadata and improved selection UI

* refactor: implement deep equality check to prevent redundant database writes and track actual document changes

* feat: include tmdb id in tv show and movie data transformations

* feat: introduce ContentPoster component to standardize media display with fallback UI and animations

* refactor: replace genre_ids with full genre objects in content data structures and UI components

* refactor: remove global genre fetching and prop drilling in favor of utility-based color generation

* refactor: remove EmZGenre interface and unused Avatar import