### PR TITLE
Add dashboard homepage with per-app widgets

### DIFF
--- a/app/components/pages/DashboardPage.tsx
+++ b/app/components/pages/DashboardPage.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, Card, Divider, Stack, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+import StyledLink from "../StyledLink";
+
+export interface DashboardCard {
+  label: string;
+  route: string;
+  icon: ReactNode;
+  color: string;
+  widget?: ReactNode;
+}
+
+export default function DashboardPage(props: {
+  title: string;
+  cards: DashboardCard[];
+}) {
+  return (
+    <Stack spacing={4} sx={{ px: 4, py: 2, width: "100%" }}>
+      <Typography variant="h1" align="center">
+        {props.title}
+      </Typography>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            sm: "repeat(2, 1fr)",
+            md: "repeat(3, 1fr)",
+          },
+          gap: 3,
+        }}
+      >
+        {props.cards.map(({ label, route, icon, color, widget }) => (
+          <StyledLink key={route} href={route}>
+            <Card
+              sx={{
+                borderRadius: 6,
+                p: 2.5,
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                gap: widget ? 1.5 : 0,
+                transition: "transform 0.15s ease, box-shadow 0.15s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: 6,
+                  bgcolor: "#e69b7a",
+                },
+              }}
+            >
+              <Stack direction="row" alignItems="center" spacing={1.5}>
+                <Box
+                  sx={{
+                    width: 44,
+                    height: 44,
+                    flexShrink: 0,
+                    borderRadius: 3,
+                    bgcolor: color,
+                    color: "white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 22,
+                  }}
+                >
+                  {icon}
+                </Box>
+                <Typography variant="h6" sx={{ flex: 1 }}>
+                  {label}
+                </Typography>
+                <ArrowForwardIcon sx={{ color: "text.secondary", fontSize: 18 }} />
+              </Stack>
+
+              {widget && (
+                <>
+                  <Divider />
+                  <Box sx={{ minHeight: 48 }}>{widget}</Box>
+                </>
+              )}
+            </Card>
+          </StyledLink>
+        ))}
+      </Box>
+    </Stack>
+  );
+}

--- a/app/countdown/Widget.tsx
+++ b/app/countdown/Widget.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Chip, Skeleton, Stack, Typography } from "@mui/material";
+import { getDocs } from "firebase/firestore";
+import * as R from "ramda";
+import { useEffect, useState } from "react";
+
+import { FbEvent } from "@shared/countdown/types";
+import { toDate } from "shared/utils";
+
+import { EVENTS_REF } from "./firebaseUtils";
+import { Event, GroupedEvents } from "./types";
+import { getSortedDates } from "./utils";
+
+const daysUntil = (dateStr: string): number | null => {
+  const date = toDate(dateStr);
+  if (date === null) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return Math.ceil((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+};
+
+export default function CountdownWidget() {
+  const [loading, setLoading] = useState(true);
+  const [groupedEvents, setGroupedEvents] = useState<GroupedEvents>({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getDocs(EVENTS_REF)
+      .then((snapshot) => {
+        if (cancelled) return;
+
+        const events = snapshot.docs.map(
+          (doc) => ({ ...(doc.data() as FbEvent), id: doc.id }) as Event,
+        );
+        setGroupedEvents(R.groupBy((event) => event.date, events) as GroupedEvents);
+      })
+      .catch((error) => console.error("Error fetching countdown widget data:", error))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <Skeleton variant="rounded" height={48} />;
+
+  const upcomingDate = getSortedDates(groupedEvents).find((date) => {
+    const days = daysUntil(date);
+    return days === null || days >= 0;
+  });
+
+  if (!upcomingDate) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No upcoming events.
+      </Typography>
+    );
+  }
+
+  const events = groupedEvents[upcomingDate];
+  const days = daysUntil(upcomingDate);
+  const label = days === null ? "D-∞" : days === 0 ? "Today" : `D-${days}`;
+
+  return (
+    <Stack sx={{ gap: 0.5 }}>
+      <Stack direction="row" alignItems="baseline" spacing={1}>
+        <Typography variant="h5" fontWeight={700} color="primary">
+          {label}
+        </Typography>
+        <Typography variant="body2" fontWeight={600} noWrap>
+          {events[0].description}
+        </Typography>
+      </Stack>
+      {events.length > 1 && (
+        <Chip
+          size="small"
+          label={`+${events.length - 1} more that day`}
+          sx={{ alignSelf: "flex-start" }}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/app/dates/Widget.tsx
+++ b/app/dates/Widget.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Skeleton, Stack, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+import { fetchAllDates } from "./firebaseUtils";
+import { PlannerDate } from "./types";
+
+export default function DatesWidget() {
+  const [loading, setLoading] = useState(true);
+  const [nextDate, setNextDate] = useState<PlannerDate | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchAllDates()
+      .then((dates) => {
+        if (cancelled) return;
+
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        const upcoming = Object.values(dates)
+          .filter((date) => date.date >= today)
+          .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+        setNextDate(upcoming[0] || null);
+      })
+      .catch((error) => console.error("Error fetching dates widget data:", error))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <Skeleton variant="rounded" height={48} />;
+
+  if (!nextDate) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No upcoming dates planned.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack sx={{ gap: 0.25 }}>
+      <Typography variant="body2" fontWeight={700} noWrap>
+        {nextDate.name}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {nextDate.date.toLocaleDateString("en-US", {
+          weekday: "long",
+          month: "short",
+          day: "numeric",
+        })}
+      </Typography>
+    </Stack>
+  );
+}

--- a/app/finance/Widget.tsx
+++ b/app/finance/Widget.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Skeleton, Stack, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+import { fetchData, fetchDocuments } from "@/utils";
+
+import { CalculatedBudget, FbBudgetWithId, ViewType } from "./types";
+import { calculateCategories } from "./utils";
+
+export default function FinanceWidget() {
+  const [loading, setLoading] = useState(true);
+  const [budget, setBudget] = useState<CalculatedBudget | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      const financeCollectionName = process.env.NEXT_PUBLIC_FINANCE_COLLECTION;
+      if (!financeCollectionName) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const [budgets, activeData] = await Promise.all([
+          fetchDocuments(financeCollectionName) as Promise<FbBudgetWithId[]>,
+          fetchData("users/shared") as Promise<{
+            activeBudgets?: string[];
+          } | null>,
+        ]);
+
+        const activeId = activeData?.activeBudgets?.[0];
+        const activeBudget = budgets.find((b) => b.id === activeId);
+
+        if (!cancelled && activeBudget) {
+          setBudget(
+            calculateCategories(activeBudget, ViewType.MONTHLY_AVERAGE),
+          );
+        }
+      } catch (error) {
+        console.error("Error fetching finance widget data:", error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <Skeleton variant="rounded" height={48} />;
+
+  if (!budget) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No active budget.
+      </Typography>
+    );
+  }
+
+  const balance = budget.categories.liquidAssets.sumMonthly;
+
+  return (
+    <Stack sx={{ gap: 0.25 }}>
+      <Typography
+        variant="overline"
+        color="text.secondary"
+        sx={{ lineHeight: 1 }}
+      >
+        Liquid assets / mo
+      </Typography>
+      <Typography variant="h5" fontWeight={700}>
+        {balance.toLocaleString("en-US", {
+          style: "currency",
+          currency: "USD",
+          maximumFractionDigits: 0,
+        })}
+      </Typography>
+      <Typography variant="caption" color="text.secondary" noWrap>
+        {budget.name}
+      </Typography>
+    </Stack>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,52 @@
-import { ROUTES_WITHOUT_HOME } from "./components/layout/SideBar";
-import RoutePage from "./components/pages/RoutePage";
+import { FiCalendar } from "react-icons/fi";
+import { HiOutlineBanknotes } from "react-icons/hi2";
+import { LuTv } from "react-icons/lu";
+import { MdOutlineTimer } from "react-icons/md";
+import { TbLocationHeart } from "react-icons/tb";
+
+import CountdownWidget from "./countdown/Widget";
+import DatesWidget from "./dates/Widget";
+import DashboardPage, { DashboardCard } from "./components/pages/DashboardPage";
+import FinanceWidget from "./finance/Widget";
+import TVWidget from "./tv/Widget";
+
+const CARDS: DashboardCard[] = [
+  {
+    route: "/finance",
+    label: "Finance",
+    icon: <HiOutlineBanknotes />,
+    color: "#7a9e4a",
+    widget: <FinanceWidget />,
+  },
+  {
+    route: "/countdown",
+    label: "Countdown",
+    icon: <MdOutlineTimer />,
+    color: "#b8763a",
+    widget: <CountdownWidget />,
+  },
+  {
+    route: "/specialOccasions",
+    label: "Special Occasions",
+    icon: <FiCalendar />,
+    color: "#904C77",
+  },
+  {
+    route: "/tv",
+    label: "TV",
+    icon: <LuTv />,
+    color: "#4a6a9e",
+    widget: <TVWidget />,
+  },
+  {
+    route: "/dates",
+    label: "Dates",
+    icon: <TbLocationHeart />,
+    color: "#c25a7c",
+    widget: <DatesWidget />,
+  },
+];
 
 export default function Home() {
-  return <RoutePage title="Apps" routes={ROUTES_WITHOUT_HOME} />;
+  return <DashboardPage title="Apps" cards={CARDS} />;
 }

--- a/app/tv/Widget.tsx
+++ b/app/tv/Widget.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Chip, Skeleton, Stack, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+import ContentPoster from "@/components/ContentPoster";
+import { ContentStatus, EmZContent } from "@shared/tv/types";
+
+import { fetchAllContentFromFirebase } from "./firebaseUtils";
+
+export default function TVWidget() {
+  const [loading, setLoading] = useState(true);
+  const [current, setCurrent] = useState<EmZContent | null>(null);
+  const [queuedCount, setQueuedCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchAllContentFromFirebase()
+      .then((snapshot) => {
+        if (cancelled) return;
+
+        const rows = snapshot.docs.map((doc) => doc.data() as EmZContent);
+        const inProgress = rows.filter(
+          (row) => ContentStatus.calculate(row) === ContentStatus.IN_PROGRESS,
+        );
+        const notStarted = rows.filter(
+          (row) => ContentStatus.calculate(row) === ContentStatus.NOT_STARTED,
+        );
+
+        setCurrent(inProgress[0] || null);
+        setQueuedCount(notStarted.length);
+      })
+      .catch((error) => console.error("Error fetching TV widget data:", error))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <Skeleton variant="rounded" height={62} />;
+
+  if (!current) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {queuedCount > 0
+          ? `${queuedCount} show${queuedCount === 1 ? "" : "s"} queued up.`
+          : "Nothing being watched right now."}
+      </Typography>
+    );
+  }
+
+  const title = current.media_type === "movie" ? current.title : current.name;
+
+  return (
+    <Stack direction="row" spacing={1.5} alignItems="center">
+      <ContentPoster
+        posterPath={current.poster_path}
+        title={title}
+        mediaType={current.media_type}
+        height={62}
+        width={44}
+        hideTitle
+        sx={{ borderRadius: 2, flexShrink: 0 }}
+      />
+      <Stack sx={{ gap: 0.25, minWidth: 0 }}>
+        <Typography variant="body2" fontWeight={700} noWrap>
+          {title}
+        </Typography>
+        <Chip size="small" label="in progress" sx={{ alignSelf: "flex-start" }} />
+      </Stack>
+    </Stack>
+  );
+}


### PR DESCRIPTION
Homepage now shows a live snapshot of each apps key info (finance balance, next countdown, current show, next planned date) alongside the existing link tiles, so the whole app card doubles as a preview. Special Occasions keeps the plain tile since it has no natural current-state to summarize.